### PR TITLE
changing naming convention of global colors

### DIFF
--- a/config/tokens.json
+++ b/config/tokens.json
@@ -246,6 +246,41 @@
         "value": "#000000",
         "type": "color",
         "description": "black shade"
+      },
+      "orange-100": {
+        "value": "#ffe3c2",
+        "type": "color",
+        "description": "very light orange"
+      },
+      "orange-500": {
+        "value": "#ff854d",
+        "type": "color",
+        "description": "mid orange"
+      },
+      "orange-600": {
+        "value": "#DB6038",
+        "type": "color",
+        "description": "darker orange"
+      },
+      "orange-800": {
+        "value": "#6F1F06",
+        "type": "color",
+        "description": "dark orange"
+      },
+      "blue-100": {
+        "value": "#E0F4F9",
+        "type": "color",
+        "description": "very light blue"
+      },
+      "blue-500": {
+        "value": "#00A0C8",
+        "type": "color",
+        "description": "mid blue"
+      },
+      "blue-700": {
+        "value": "#005D90",
+        "type": "color",
+        "description": "dark blue"
       }
     },
     "fontFamilies": {
@@ -722,7 +757,7 @@
       }
     },
     "Gradient primary button org": {
-      "value": "linear-gradient(180deg, #9ecb0a 0%, #82a708 100%)",
+      "value": "linear-gradient(180deg, $color.green-500 0%, $color.green-600 100%)",
       "type": "color"
     },
     "button-radius": {
@@ -739,6 +774,11 @@
       "value": "{borderRadius.2xs}",
       "type": "borderRadius",
       "description": "All cards have this radius"
+    },
+    "seperator": {
+      "value": "{spacing.xl}",
+      "type": "spacing",
+      "description": "space between elements itself"
     }
   },
   "me": {},

--- a/config/tokens.json
+++ b/config/tokens.json
@@ -757,7 +757,7 @@
       }
     },
     "Gradient primary button org": {
-      "value": "linear-gradient(180deg, $color.green-500 0%, $color.green-600 100%)",
+      "value": "linear-gradient(180deg, {color.green-500} 0%, {color.green-600} 100%)",
       "type": "color"
     },
     "button-radius": {

--- a/config/tokens.json
+++ b/config/tokens.json
@@ -309,7 +309,7 @@
       }
     },
     "text": {
-      "3XL": {
+      "3xl": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.regular}",
@@ -323,7 +323,7 @@
         "type": "typography",
         "description": "3-Large font size is used for primary headlines on desktop."
       },
-      "3XL Bold": {
+      "3xl-bold": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.bold}",
@@ -337,7 +337,7 @@
         "type": "typography",
         "description": "3XL font size is used for primary headlines on desktop."
       },
-      "2XL": {
+      "2xl": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.regular}",
@@ -351,7 +351,7 @@
         "type": "typography",
         "description": "2XL font size is used for secondary headlines on desktop and primary headlines on mobile."
       },
-      "2XL Bold": {
+      "2xl-bold": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.bold}",
@@ -365,7 +365,7 @@
         "type": "typography",
         "description": "2XL font size is used for secondary headlines on desktop and primary headlines on mobile."
       },
-      "XL": {
+      "xl": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.regular}",
@@ -379,7 +379,7 @@
         "type": "typography",
         "description": "XL font size is used for large sub-headlines and secondary headlines on mobile."
       },
-      "XL Bold": {
+      "xl-bold": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.bold}",
@@ -393,7 +393,7 @@
         "type": "typography",
         "description": "XL font size is used for large sub-headlines and secondary headlines on mobile."
       },
-      "Large": {
+      "large": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.regular}",
@@ -407,7 +407,7 @@
         "type": "typography",
         "description": "Large font size is used for small sub-headings, button- and input-labels."
       },
-      "Large Bold": {
+      "large-bold": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.bold}",
@@ -435,7 +435,7 @@
         "type": "typography",
         "description": "Medium font size is used for the body text."
       },
-      "Body Bold": {
+      "body-bold": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.bold}",
@@ -449,7 +449,7 @@
         "type": "typography",
         "description": "Medium font size is used for the body text. Bold for highlighting."
       },
-      "Link bold": {
+      "link-bold": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.bold}",
@@ -462,7 +462,7 @@
         },
         "type": "typography"
       },
-      "Link regular": {
+      "link-regular": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.regular}",
@@ -475,7 +475,7 @@
         },
         "type": "typography"
       },
-      "Small": {
+      "small": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.regular}",
@@ -489,7 +489,7 @@
         "type": "typography",
         "description": "Small font size should be used sparingly for annotations, descriptions, and similar content."
       },
-      "Small Bold": {
+      "small-bold": {
         "value": {
           "fontFamily": "$fontFamilies.fira-sans",
           "fontWeight": "{fontWeights.bold}",

--- a/config/tokens.json
+++ b/config/tokens.json
@@ -146,103 +146,103 @@
         "type": "paragraphSpacing"
       }
     },
-    "Color": {
-      "Gray 100": {
+    "color": {
+      "gray-100": {
         "value": "#f8f8f8",
         "type": "color",
         "description": "the lightest gray"
       },
-      "Gray 200": {
+      "gray-200": {
         "value": "#eeeeee",
         "type": "color",
         "description": "lighter gray"
       },
-      "Gray 300": {
+      "gray-300": {
         "value": "#cccccc",
         "type": "color",
         "description": "lightish gray"
       },
-      "Gray 500": {
+      "gray-500": {
         "value": "#919191",
         "type": "color",
         "description": "mid gray"
       },
-      "Gray 700": {
+      "gray-700": {
         "value": "#636363",
         "type": "color",
         "description": "darker gray"
       },
-      "Gray 900": {
+      "gray-900": {
         "value": "#282828",
         "type": "color",
         "description": "very dark gray"
       },
-      "Green 100": {
+      "green-100": {
         "value": "#f5fccc",
         "type": "color",
         "description": "very light green"
       },
-      "Green 500": {
+      "green-500": {
         "value": "#9ecb0a",
         "type": "color",
         "description": "mid green"
       },
-      "Green 600": {
+      "green-600": {
         "value": "#85ac1c",
         "type": "color",
         "description": "bit darker green"
       },
-      "Green 800": {
+      "green-800": {
         "value": "#357c00",
         "type": "color",
         "description": "very dark green"
       },
-      "Purple 600": {
+      "purple-600": {
         "value": "#6d2c64",
         "type": "color",
         "description": "dark purple"
       },
-      "Teal 500": {
+      "teal-500": {
         "value": "#60b2a4",
         "type": "color",
         "description": "light teal"
       },
-      "Teal 700": {
+      "teal-700": {
         "value": "#2b8475",
         "type": "color",
         "description": "dark teal"
       },
-      "Teal 800": {
+      "teal-800": {
         "value": "#1e6761",
         "type": "color",
         "description": "darkest teal"
       },
-      "Yellow 100": {
+      "yellow-100": {
         "value": "#fff4d2",
         "type": "color",
         "description": "lightest yellow"
       },
-      "Yellow 400": {
+      "yellow-400": {
         "value": "#f6ce46",
         "type": "color",
         "description": "mid yelllow"
       },
-      "Red 200": {
+      "red-200": {
         "value": "#ffc4c4",
         "type": "color",
         "description": "lightest red"
       },
-      "Red 700": {
+      "red-700": {
         "value": "#d32b43",
         "type": "color",
         "description": "darker red"
       },
-      "White": {
+      "white": {
         "value": "#ffffff",
         "type": "color",
         "description": "white shade"
       },
-      "Black": {
+      "black": {
         "value": "#000000",
         "type": "color",
         "description": "black shade"
@@ -609,114 +609,114 @@
   "org": {
     "Color": {
       "bg-light": {
-        "value": "{Color.Gray 100}",
+        "value": "{color.gray-100}",
         "type": "color",
         "description": "Planned color / as section UI Color"
       },
       "bg": {
-        "value": "{Color.Gray 200}",
+        "value": "{color.gray-200}",
         "type": "color",
         "description": "Backround main"
       },
       "border": {
-        "value": "{Color.Gray 300}",
+        "value": "{color.gray-300}",
         "type": "color",
         "description": "planned as border color"
       },
       "text-mute": {
-        "value": "{Color.Gray 500}",
+        "value": "{color.gray-500}",
         "type": "color",
         "description": "text disabled"
       },
       "text-light": {
-        "value": "{Color.Gray 700}",
+        "value": "{color.gray-700}",
         "type": "color",
         "description": "text color secondary"
       },
       "text": {
-        "value": "{Color.Gray 900}",
+        "value": "{color.gray-900}",
         "type": "color",
         "description": "planned text color"
       },
       "bg-success": {
-        "value": "{Color.Green 100}",
+        "value": "{color.green-100}",
         "type": "color",
         "description": "bg color success"
       },
       "button": {
-        "value": "{Color.Green 500}",
+        "value": "{color.green-500}",
         "type": "color",
         "description": "color for the primary buttons"
       },
       "brand": {
-        "value": "{Color.Green 500}",
+        "value": "{color.green-500}",
         "type": "color",
         "description": "offcial brand color token"
       },
       "button-dark": {
-        "value": "{Color.Green 600}",
+        "value": "{color.green-600}",
         "type": "color",
         "description": "primary button hover"
       },
       "link": {
-        "value": "{Color.Green 800}",
+        "value": "{color.green-800}",
         "type": "color",
         "description": "Linkcolor text"
       },
       "accent": {
-        "value": "{Color.Purple 600}",
+        "value": "{color.purple-600}",
         "type": "color",
         "description": "accent color"
       },
       "forms-bg": {
-        "value": "{Color.Teal 500}",
+        "value": "{color.teal-500}",
         "type": "color",
         "description": "bg color behind every form. note: there is a surface white in between"
       },
       "progressbar": {
-        "value": "{Color.Teal 700}",
+        "value": "{color.teal-700}",
         "type": "color",
         "description": "Fill and Stroke of Donation Progressbar"
       },
       "warning-bg": {
-        "value": "{Color.Yellow 100}",
+        "value": "{color.yellow-100}",
         "type": "color",
         "description": "bg color warning"
       },
       "bg-yellow": {
-        "value": "{Color.Yellow 400}",
+        "value": "{color.yellow-400}",
         "type": "color",
         "description": "bg color yellow"
       },
       "error-bg": {
-        "value": "{Color.Red 200}",
+        "value": "{color.red-200}",
         "type": "color",
         "description": "bg color warning"
       },
       "text-error": {
-        "value": "{Color.Red 700}",
+        "value": "{color.red-700}",
         "type": "color",
         "description": "text color error"
       },
       "surface": {
-        "value": "{Color.White}",
+        "value": "{color.white}",
         "type": "color",
         "description": "Surface is always white"
       },
       "text-black": {
-        "value": "{Color.Black}",
+        "value": "{color.black}",
         "type": "color",
         "description": "Current text color"
       }
     },
     "manage--Color": {
       "navi": {
-        "value": "{Color.Teal 700}",
+        "value": "{color.teal-700}",
         "type": "color",
         "description": "bg color navigation mng area for users on org"
       },
       "navi-dark": {
-        "value": "{Color.Teal 800}",
+        "value": "{color.teal-800}",
         "type": "color",
         "description": "bg nav mng , hover active menu pnt"
       }
@@ -744,17 +744,17 @@
   "me": {},
   "at": {
     "button": {
-      "value": "{Color.Green 500}",
+      "value": "{color.green-500}",
       "type": "color",
       "description": "Background color of primary buttons."
     },
     "text-black": {
-      "value": "{Color.Black}",
+      "value": "{color.black}",
       "type": "color",
       "description": "Text on primary buttons."
     },
     "button-shadow": {
-      "value": "{Color.Green 800}",
+      "value": "{color.green-800}",
       "type": "color",
       "description": "Dropshadow of primary buttons."
     },
@@ -764,29 +764,29 @@
         "y": "2",
         "blur": "1",
         "spread": "0",
-        "color": "{Color.Green 800}",
+        "color": "{color.green-800}",
         "type": "dropShadow"
       },
       "type": "boxShadow",
       "description": "Drop shadow of inactive primary button."
     },
     "button-hover": {
-      "value": "{Color.Green 600}",
+      "value": "{color.green-600}",
       "type": "color",
       "description": "Hover for primary buttons."
     },
     "text-white": {
-      "value": "{Color.White}",
+      "value": "{color.white}",
       "type": "color",
       "description": "Button label on hover."
     },
     "bg-disabled": {
-      "value": "{Color.Gray 300}",
+      "value": "{color.gray-300}",
       "type": "color",
       "description": "Button disabled"
     },
     "text-light": {
-      "value": "{Color.Gray 700}",
+      "value": "{color.gray-700}",
       "type": "color",
       "description": "Button label on disabled."
     }


### PR DESCRIPTION
we want to have a mor easy typing in code
therefore we only use small capitals and no spaces. 

- a dot is cascading down
- a minus replaces the space