### PR TITLE
allow for old token reference syntax when embedded inside a string value

### DIFF
--- a/config/style-dictionary/parsers.js
+++ b/config/style-dictionary/parsers.js
@@ -7,7 +7,7 @@ StyleDictionary.registerParser({
     // replace the old reference syntax with the one style-dictionary understands
     // e.g. "$fontFamilies.fira-sans" -> "{fontFamilies.fira-sans}"
     // see https://docs.tokens.studio/tokens/aliases
-    const tokens = JSON.parse(contents.replace(/\$([^"]+)/g, `{$1}`))
+    const tokens = JSON.parse(contents.replace(/\$([^"\s]+)/g, `{$1}`))
 
     // strip away the global key for global token set but keep the themes nested
     // this is necessary, because the references from Figma Tokens do not include the token set key


### PR DESCRIPTION
We had the case when the [old reference syntax](https://docs.tokens.studio/tokens/aliases) (`$my-token`) was used inside a string value (e.g. linear-gradient) and `yarn build-tokens` failed, because style dictionary doesn't understand it: See related [commit](https://github.com/betterplace/betterplace-design-system/pull/27/commits/6598393cf32697936d03ddcf530b54713f7e9c38#diff-adbec76027d1b744b72d47143f06b9a623251ad06d44fae1f28e2e80f690ac2cL725-R760). These references will now be replaced as well, using the whitespace selector in the regex.

Note: this also means that we should *not* use any whitespace in the token names anymore!

```
"value": "linear-gradient(180deg, $color.green-500 0%, $color.green-600 100%)",
```

will be transformed to:

```
"value": "linear-gradient(180deg, {color.green-500} 0%, {color.green-600} 100%)",